### PR TITLE
Fix server paths after refactor

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,13 +4,8 @@ const path = require('path');
 const fs = require('fs');
 const { v4: uuidv4 } = require('uuid');
 const dotenv = require('dotenv');
-const GameDesignerAgent = require('./agents/GameDesignerAgent');
-const MechanicSynthesizerAgent = require('./agents/MechanicSynthesizerAgent');
-const GameBuilderAgent = require('./agents/GameBuilderAgent');
-const SaveAgent = require('./agents/SaveAgent');
-const logGame = require('./utils/logGame');
-const PlannerAgent = require('./agents/PlannerAgent');
-const { runPipeline } = require('./pipeline-v2/controller');
+// Legacy imports removed after refactor. Core pipeline lives in controller.js
+const { runPipeline } = require('./controller');
 dotenv.config();
 
 const app = express();

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -16,7 +16,8 @@ const logger = createLogger({
   defaultMeta: { service: 'pipeline-v2' },
   transports: [
     new transports.Console({ format: format.simple() }),
-    new transports.File({ filename: path.join(__dirname, '../../../logs/pipeline-v2.log') })
+    // Write logs to server/logs relative to project root
+    new transports.File({ filename: path.join(__dirname, '..', 'logs', 'pipeline-v2.log') })
   ]
 });
 


### PR DESCRIPTION
## Summary
- remove obsolete agent imports from server entrypoint
- update pipeline controller import path
- correct logger file path to use server/logs directory

## Testing
- `npm test` *(fails: jest not found)*
- `npx jest` *(fails: forbidden to fetch jest)*

------
https://chatgpt.com/codex/tasks/task_e_6841b228ba6c832382badff69e4c2a98